### PR TITLE
Add Ntfy notification support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -123,6 +123,13 @@ UNIFI_API_KEY=replace-me
 # STOPLIGA_GOTIFY_TOKEN=replace-me
 # STOPLIGA_GOTIFY_TOKEN_FILE=/run/secrets/gotify_token
 
+# Ntfy
+# STOPLIGA_NTFY_URL=https://ntfy.sh
+# STOPLIGA_NTFY_TOPIC=stopliga-alerts
+# STOPLIGA_NTFY_TOKEN=replace-me
+# STOPLIGA_NTFY_TOKEN_FILE=/run/secrets/ntfy_token
+# STOPLIGA_NTFY_PRIORITY=3
+
 # Telegram
 # Set either STOPLIGA_TELEGRAM_CHAT_ID or STOPLIGA_TELEGRAM_GROUP_ID.
 # STOPLIGA_TELEGRAM_BOT_TOKEN=123456:replace-me

--- a/README.md
+++ b/README.md
@@ -195,11 +195,21 @@ The `/config` mount is optional.
 StopLiga can also notify through:
 
 - Gotify
+- Ntfy
 - Telegram
 
 When notifications are configured and StopLiga runs in `loop` mode, it sends a startup test message once when the service begins so you can verify delivery without waiting for the next route change.
 
 Most users can ignore notifications until the main sync is working.
+
+Minimal Ntfy `.env`:
+
+```dotenv
+STOPLIGA_NTFY_URL=https://ntfy.sh
+STOPLIGA_NTFY_TOPIC=stopliga-alerts
+# STOPLIGA_NTFY_TOKEN=replace-me
+STOPLIGA_NTFY_PRIORITY=3
+```
 
 ## Feed Safety Ceiling
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -65,6 +65,12 @@ verify_tls = false
 # gotify_url = "https://gotify.example.com"
 # gotify_token = "replace-me"
 #
+# Ntfy
+# ntfy_url = "https://ntfy.sh"
+# ntfy_topic = "stopliga-alerts"
+# ntfy_token = "replace-me"
+# ntfy_priority = 3
+#
 # Telegram
 # telegram_bot_token = "123456:replace-me"
 # telegram_chat_id = "123456789"

--- a/src/stopliga/config.py
+++ b/src/stopliga/config.py
@@ -177,6 +177,24 @@ def _validate_gotify_url(url: str, *, allow_plain_http: bool) -> None:
         raise ConfigError("gotify_url must use https unless STOPLIGA_GOTIFY_ALLOW_PLAIN_HTTP=true")
 
 
+def _validate_ntfy_url(url: str, *, allow_plain_http: bool) -> None:
+    _validate_notification_url(url, field_name="ntfy_url")
+    parsed = urlparse(url)
+    if parsed.scheme == "http" and not allow_plain_http:
+        raise ConfigError("ntfy_url must use https unless STOPLIGA_NTFY_ALLOW_PLAIN_HTTP=true")
+    if parsed.query or parsed.fragment:
+        raise ConfigError("ntfy_url must not include query or fragment components")
+
+
+def _validate_ntfy_topic(topic: str) -> None:
+    if not topic.strip():
+        raise ConfigError("ntfy_topic must not be empty")
+    if topic != topic.strip():
+        raise ConfigError("ntfy_topic must not contain leading or trailing whitespace")
+    if any(ch.isspace() for ch in topic) or any(ch in topic for ch in "/?#"):
+        raise ConfigError("ntfy_topic must be a single topic name without whitespace, slashes, query or fragment")
+
+
 def _validate_api_base_url(url: str, *, field_name: str) -> None:
     parsed = urlparse(url)
     if parsed.scheme not in {"https", "http"}:
@@ -315,6 +333,10 @@ def load_config_file(path: Path | None) -> dict[str, Any]:
         "gotify_url": notifications.get("gotify_url"),
         "gotify_token": notifications.get("gotify_token"),
         "gotify_priority": notifications.get("gotify_priority"),
+        "ntfy_url": notifications.get("ntfy_url"),
+        "ntfy_topic": notifications.get("ntfy_topic"),
+        "ntfy_token": notifications.get("ntfy_token"),
+        "ntfy_priority": notifications.get("ntfy_priority"),
         "telegram_bot_token": notifications.get("telegram_bot_token"),
         "telegram_chat_id": notifications.get("telegram_chat_id"),
         "telegram_group_id": notifications.get("telegram_group_id"),
@@ -326,6 +348,9 @@ def load_config_file(path: Path | None) -> dict[str, Any]:
         "gotify_verify_tls": notifications.get("gotify_verify_tls"),
         "gotify_ca_file": notifications.get("gotify_ca_file"),
         "gotify_allow_plain_http": notifications.get("gotify_allow_plain_http"),
+        "ntfy_verify_tls": notifications.get("ntfy_verify_tls"),
+        "ntfy_ca_file": notifications.get("ntfy_ca_file"),
+        "ntfy_allow_plain_http": notifications.get("ntfy_allow_plain_http"),
         "telegram_verify_tls": notifications.get("telegram_verify_tls"),
         "telegram_ca_file": notifications.get("telegram_ca_file"),
     }
@@ -404,6 +429,10 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--gotify-url", default=None, help="Gotify server URL")
     parser.add_argument("--gotify-token", default=None, help="Gotify application token")
     parser.add_argument("--gotify-priority", type=int, default=None, help="Gotify priority")
+    parser.add_argument("--ntfy-url", default=None, help="Ntfy server URL")
+    parser.add_argument("--ntfy-topic", default=None, help="Ntfy topic")
+    parser.add_argument("--ntfy-token", default=None, help="Optional Ntfy access token")
+    parser.add_argument("--ntfy-priority", type=int, default=None, help="Ntfy priority from 1 to 5")
     parser.add_argument("--telegram-bot-token", default=None, help="Telegram bot token")
     parser.add_argument("--telegram-chat-id", default=None, help="Telegram user/chat id")
     parser.add_argument("--telegram-group-id", default=None, help="Telegram group or supergroup id")
@@ -995,6 +1024,35 @@ def load_config(args: argparse.Namespace, environ: Mapping[str, str] | None = No
             ),
             field_name="gotify_priority",
         ),
+        ntfy_url=_first(
+            args.ntfy_url, _env_value(env, "STOPLIGA_NTFY_URL"), file_cfg.get("ntfy_url"), DEFAULTS.ntfy_url
+        ),
+        ntfy_topic=_normalize_optional_string(
+            _first(
+                args.ntfy_topic,
+                _env_value(env, "STOPLIGA_NTFY_TOPIC"),
+                file_cfg.get("ntfy_topic"),
+                DEFAULTS.ntfy_topic,
+            ),
+            field_name="ntfy_topic",
+        ),
+        ntfy_token=_first(
+            args.ntfy_token,
+            _env_secret_first(
+                env, field_name="ntfy_token", key="STOPLIGA_NTFY_TOKEN", key_file="STOPLIGA_NTFY_TOKEN_FILE"
+            ),
+            file_cfg.get("ntfy_token"),
+            DEFAULTS.ntfy_token,
+        ),
+        ntfy_priority=_parse_int(
+            _first(
+                args.ntfy_priority,
+                _env_value(env, "STOPLIGA_NTFY_PRIORITY"),
+                file_cfg.get("ntfy_priority"),
+                DEFAULTS.ntfy_priority,
+            ),
+            field_name="ntfy_priority",
+        ),
         telegram_bot_token=_first(
             args.telegram_bot_token,
             _env_secret_first(
@@ -1060,6 +1118,23 @@ def load_config(args: argparse.Namespace, environ: Mapping[str, str] | None = No
             ),
             field_name="gotify_allow_plain_http",
         ),
+        ntfy_verify_tls=(
+            _parse_bool(value, field_name="ntfy_verify_tls")
+            if (value := _first(_env_value(env, "STOPLIGA_NTFY_VERIFY_TLS"), file_cfg.get("ntfy_verify_tls")))
+            is not None
+            else None
+        ),
+        ntfy_ca_file=_parse_path(value, field_name="ntfy_ca_file")
+        if (value := _first(_env_value(env, "STOPLIGA_NTFY_CA_FILE"), file_cfg.get("ntfy_ca_file")))
+        else None,
+        ntfy_allow_plain_http=_parse_bool(
+            _first(
+                _env_value(env, "STOPLIGA_NTFY_ALLOW_PLAIN_HTTP"),
+                file_cfg.get("ntfy_allow_plain_http"),
+                DEFAULTS.ntfy_allow_plain_http,
+            ),
+            field_name="ntfy_allow_plain_http",
+        ),
         telegram_verify_tls=(
             _parse_bool(value, field_name="telegram_verify_tls")
             if (value := _first(_env_value(env, "STOPLIGA_TELEGRAM_VERIFY_TLS"), file_cfg.get("telegram_verify_tls")))
@@ -1118,6 +1193,11 @@ def validate_config(config: Config, *, validate_connection: bool) -> None:
         raise ConfigError("STOPLIGA_VPN_NAME and STOPLIGA_TARGETS are UniFi-only bootstrap options")
     if bool(config.gotify_url) != bool(config.gotify_token):
         raise ConfigError("Gotify notifications require both STOPLIGA_GOTIFY_URL and STOPLIGA_GOTIFY_TOKEN")
+    ntfy_configured = bool(config.ntfy_url or config.ntfy_topic or config.ntfy_token)
+    if ntfy_configured and not (config.ntfy_url and config.ntfy_topic):
+        raise ConfigError("Ntfy notifications require STOPLIGA_NTFY_URL and STOPLIGA_NTFY_TOPIC")
+    if not 1 <= config.ntfy_priority <= 5:
+        raise ConfigError("ntfy_priority must be between 1 and 5")
     if config.telegram_chat_id and config.telegram_group_id:
         raise ConfigError("Set either STOPLIGA_TELEGRAM_CHAT_ID or STOPLIGA_TELEGRAM_GROUP_ID, not both")
     telegram_target = config.resolved_telegram_chat_id()
@@ -1146,6 +1226,10 @@ def validate_config(config: Config, *, validate_connection: bool) -> None:
         _validate_host(config.host or "", field_name="UNIFI_HOST")
     if config.gotify_url:
         _validate_gotify_url(config.gotify_url, allow_plain_http=config.gotify_allow_plain_http)
+    if config.ntfy_url:
+        _validate_ntfy_url(config.ntfy_url, allow_plain_http=config.ntfy_allow_plain_http)
+    if config.ntfy_topic:
+        _validate_ntfy_topic(config.ntfy_topic)
     if config.telegram_bot_token:
         if config.telegram_verify_tls is False:
             raise ConfigError("telegram_verify_tls=false is not supported; Telegram notifications must verify TLS")

--- a/src/stopliga/models.py
+++ b/src/stopliga/models.py
@@ -69,6 +69,10 @@ class Config:
     gotify_url: str | None = None
     gotify_token: str | None = None
     gotify_priority: int = 5
+    ntfy_url: str | None = None
+    ntfy_topic: str | None = None
+    ntfy_token: str | None = None
+    ntfy_priority: int = 3
     telegram_bot_token: str | None = None
     telegram_chat_id: str | None = None
     telegram_group_id: str | None = None
@@ -80,6 +84,9 @@ class Config:
     gotify_verify_tls: bool | None = None
     gotify_ca_file: Path | None = None
     gotify_allow_plain_http: bool = False
+    ntfy_verify_tls: bool | None = None
+    ntfy_ca_file: Path | None = None
+    ntfy_allow_plain_http: bool = False
     telegram_verify_tls: bool | None = None
     telegram_ca_file: Path | None = None
 
@@ -115,7 +122,9 @@ class Config:
 
     def has_notifications(self) -> bool:
         return bool(
-            (self.gotify_url and self.gotify_token) or (self.telegram_bot_token and self.resolved_telegram_chat_id())
+            (self.gotify_url and self.gotify_token)
+            or (self.ntfy_url and self.ntfy_topic)
+            or (self.telegram_bot_token and self.resolved_telegram_chat_id())
         )
 
     def resolved_telegram_chat_id(self) -> str | None:

--- a/src/stopliga/notifier.py
+++ b/src/stopliga/notifier.py
@@ -9,7 +9,7 @@ import urllib.error
 import urllib.request
 from dataclasses import dataclass
 from typing import Any
-from urllib.parse import urlparse, urlunparse
+from urllib.parse import quote, urlparse, urlunparse
 
 from .errors import NetworkError, NotificationDeliveryError, StopLigaError
 from .logging_utils import log_event
@@ -122,12 +122,91 @@ def _post_json(
     return None
 
 
+def _post_text(
+    url: str,
+    message: str,
+    *,
+    headers: dict[str, str] | None = None,
+    timeout: float,
+    retries: int,
+    verify_tls: bool,
+    ca_file,
+) -> dict[str, Any] | None:
+    body = message.encode("utf-8")
+    opener = urllib.request.build_opener(
+        urllib.request.HTTPSHandler(context=make_ssl_context(verify=verify_tls, ca_file=ca_file))
+    )
+    safe_url = _safe_notification_url(url)
+    logger = logging.getLogger("stopliga.notify")
+    request_headers = {
+        "Content-Type": "text/plain; charset=utf-8",
+        "Accept": "application/json",
+        "User-Agent": DEFAULT_USER_AGENT,
+        **(headers or {}),
+    }
+    for attempt in range(1, max(1, retries) + 1):
+        request = urllib.request.Request(
+            url,
+            data=body,
+            headers=request_headers,
+            method="POST",
+        )
+        try:
+            with opener.open(request, timeout=timeout) as response:
+                raw = response.read()
+                if not raw:
+                    return None
+                try:
+                    parsed = json.loads(raw.decode("utf-8", errors="replace"))
+                except json.JSONDecodeError:
+                    return None
+                return parsed if isinstance(parsed, dict) else None
+        except urllib.error.HTTPError as exc:
+            if exc.code in {408, 429, 500, 502, 503, 504} and attempt < retries:
+                log_event(
+                    logger,
+                    logging.WARNING,
+                    "notification_retry",
+                    url=safe_url,
+                    attempt=attempt,
+                    retries=retries,
+                    status=exc.code,
+                )
+                sleep_with_backoff(attempt)
+                continue
+            raise NetworkError(f"Notification request failed for {safe_url}: HTTP {exc.code}") from exc
+        except (urllib.error.URLError, TimeoutError, OSError, ssl.SSLError) as exc:
+            if attempt < retries:
+                log_event(
+                    logger,
+                    logging.WARNING,
+                    "notification_retry",
+                    url=safe_url,
+                    attempt=attempt,
+                    retries=retries,
+                    error=exc,
+                )
+                sleep_with_backoff(attempt)
+                continue
+            raise NetworkError(f"Notification request failed for {safe_url}: {exc}") from exc
+    return None
+
+
 def _gotify_request_config(config: Config) -> ProviderRequestConfig:
     return ProviderRequestConfig(
         timeout=config.notification_timeout,
         retries=config.notification_retries,
         verify_tls=config.gotify_verify_tls if config.gotify_verify_tls is not None else config.notification_verify_tls,
         ca_file=config.gotify_ca_file or config.notification_ca_file,
+    )
+
+
+def _ntfy_request_config(config: Config) -> ProviderRequestConfig:
+    return ProviderRequestConfig(
+        timeout=config.notification_timeout,
+        retries=config.notification_retries,
+        verify_tls=config.ntfy_verify_tls if config.ntfy_verify_tls is not None else config.notification_verify_tls,
+        ca_file=config.ntfy_ca_file or config.notification_ca_file,
     )
 
 
@@ -150,6 +229,8 @@ def _configured_notification_providers(config: Config) -> list[str]:
     providers: list[str] = []
     if config.gotify_url and config.gotify_token:
         providers.append("Gotify")
+    if config.ntfy_url and config.ntfy_topic:
+        providers.append("Ntfy")
     if config.telegram_bot_token and config.resolved_telegram_chat_id():
         providers.append("Telegram")
     return providers
@@ -303,6 +384,30 @@ def _send_notification_message(config: Config, *, title: str, message: str) -> N
         except StopLigaError as exc:
             failures["gotify"] = str(exc)
             log_event(logger, logging.ERROR, "notification_provider_failed", provider="gotify", error=exc)
+
+    if config.ntfy_url and config.ntfy_topic:
+        try:
+            ntfy_url = config.ntfy_url.rstrip("/") + "/" + quote(config.ntfy_topic, safe="")
+            request_config = _ntfy_request_config(config)
+            headers = {
+                "Title": title,
+                "Priority": str(config.ntfy_priority),
+            }
+            if config.ntfy_token:
+                headers["Authorization"] = f"Bearer {config.ntfy_token}"
+            _post_text(
+                ntfy_url,
+                message,
+                headers=headers,
+                timeout=request_config.timeout,
+                retries=request_config.retries,
+                verify_tls=request_config.verify_tls,
+                ca_file=request_config.ca_file,
+            )
+            log_event(logger, logging.INFO, "notification_sent", provider="ntfy")
+        except StopLigaError as exc:
+            failures["ntfy"] = str(exc)
+            log_event(logger, logging.ERROR, "notification_provider_failed", provider="ntfy", error=exc)
 
     telegram_target = config.resolved_telegram_chat_id()
     if config.telegram_bot_token and telegram_target:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -459,6 +459,38 @@ api_key = "file-api-key"
                 },
             )
 
+    def test_ntfy_configuration_loads_from_environment(self) -> None:
+        parser = build_parser()
+        args = parser.parse_args([])
+        config = load_config(
+            args,
+            {
+                "UNIFI_HOST": "10.0.0.2",
+                "UNIFI_API_KEY": "test-api-key",
+                "STOPLIGA_NTFY_URL": "https://ntfy.sh",
+                "STOPLIGA_NTFY_TOPIC": "stopliga-test",
+                "STOPLIGA_NTFY_TOKEN": "tk_test",
+                "STOPLIGA_NTFY_PRIORITY": "4",
+            },
+        )
+        self.assertEqual(config.ntfy_url, "https://ntfy.sh")
+        self.assertEqual(config.ntfy_topic, "stopliga-test")
+        self.assertEqual(config.ntfy_token, "tk_test")
+        self.assertEqual(config.ntfy_priority, 4)
+
+    def test_partial_ntfy_configuration_is_rejected(self) -> None:
+        parser = build_parser()
+        args = parser.parse_args([])
+        with self.assertRaises(ConfigError):
+            load_config(
+                args,
+                {
+                    "UNIFI_HOST": "10.0.0.2",
+                    "UNIFI_API_KEY": "test-api-key",
+                    "STOPLIGA_NTFY_URL": "https://ntfy.sh",
+                },
+            )
+
     def test_partial_telegram_configuration_is_rejected(self) -> None:
         parser = build_parser()
         args = parser.parse_args([])
@@ -543,6 +575,20 @@ api_key = "file-api-key"
                 },
             )
 
+    def test_ntfy_url_with_embedded_credentials_is_rejected(self) -> None:
+        parser = build_parser()
+        args = parser.parse_args([])
+        with self.assertRaises(ConfigError):
+            load_config(
+                args,
+                {
+                    "UNIFI_HOST": "10.0.0.2",
+                    "UNIFI_API_KEY": "test-api-key",
+                    "STOPLIGA_NTFY_URL": "https://user:pass@ntfy.example",
+                    "STOPLIGA_NTFY_TOPIC": "stopliga",
+                },
+            )
+
     def test_notification_retries_must_be_positive(self) -> None:
         parser = build_parser()
         args = parser.parse_args([])
@@ -591,6 +637,49 @@ api_key = "file-api-key"
                     "UNIFI_API_KEY": "test-api-key",
                     "STOPLIGA_GOTIFY_URL": "http://gotify.example",
                     "STOPLIGA_GOTIFY_TOKEN": "token",
+                },
+            )
+
+    def test_ntfy_plain_http_requires_explicit_override(self) -> None:
+        parser = build_parser()
+        args = parser.parse_args([])
+        with self.assertRaises(ConfigError):
+            load_config(
+                args,
+                {
+                    "UNIFI_HOST": "10.0.0.2",
+                    "UNIFI_API_KEY": "test-api-key",
+                    "STOPLIGA_NTFY_URL": "http://ntfy.example",
+                    "STOPLIGA_NTFY_TOPIC": "stopliga",
+                },
+            )
+
+    def test_ntfy_topic_must_be_single_path_segment(self) -> None:
+        parser = build_parser()
+        args = parser.parse_args([])
+        with self.assertRaises(ConfigError):
+            load_config(
+                args,
+                {
+                    "UNIFI_HOST": "10.0.0.2",
+                    "UNIFI_API_KEY": "test-api-key",
+                    "STOPLIGA_NTFY_URL": "https://ntfy.example",
+                    "STOPLIGA_NTFY_TOPIC": "alerts/stopliga",
+                },
+            )
+
+    def test_ntfy_priority_must_be_between_one_and_five(self) -> None:
+        parser = build_parser()
+        args = parser.parse_args([])
+        with self.assertRaises(ConfigError):
+            load_config(
+                args,
+                {
+                    "UNIFI_HOST": "10.0.0.2",
+                    "UNIFI_API_KEY": "test-api-key",
+                    "STOPLIGA_NTFY_URL": "https://ntfy.example",
+                    "STOPLIGA_NTFY_TOPIC": "stopliga",
+                    "STOPLIGA_NTFY_PRIORITY": "6",
                 },
             )
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -65,6 +65,7 @@ class FakeState:
     linked_list_update_calls: int = 0
     fail_linked_list_update_on_calls: tuple[int, ...] = ()
     gotify_messages: list[dict[str, Any]] = field(default_factory=list)
+    ntfy_messages: list[dict[str, Any]] = field(default_factory=list)
     telegram_messages: list[dict[str, Any]] = field(default_factory=list)
 
     def __post_init__(self) -> None:
@@ -111,6 +112,13 @@ class FakeUniFiHandler(BaseHTTPRequestHandler):
         raw = self.rfile.read(length) if length else b"{}"
         payload = json.loads(raw.decode("utf-8"))
         self.state.request_bodies.append((self.path, clone(payload)))
+        return payload
+
+    def _read_text(self) -> str:
+        length = int(self.headers.get("Content-Length", "0"))
+        raw = self.rfile.read(length) if length else b""
+        payload = raw.decode("utf-8")
+        self.state.request_bodies.append((self.path, {"text": payload}))
         return payload
 
     def _send_json(self, status: int, payload: Any, *, headers: dict[str, str] | None = None) -> None:
@@ -169,6 +177,20 @@ class FakeUniFiHandler(BaseHTTPRequestHandler):
             payload = self._read_json()
             self.state.gotify_messages.append(payload)
             self._send_json(200, {"id": len(self.state.gotify_messages)})
+            return
+
+        if path.startswith("/ntfy/"):
+            payload = self._read_text()
+            self.state.ntfy_messages.append(
+                {
+                    "path": path,
+                    "body": payload,
+                    "title": self.headers.get("Title"),
+                    "priority": self.headers.get("Priority"),
+                    "authorization": self.headers.get("Authorization"),
+                }
+            )
+            self._send_json(200, {"id": f"ntfy-{len(self.state.ntfy_messages)}"})
             return
 
         if path.startswith("/telegram/bot") and path.endswith("/sendMessage"):
@@ -1513,6 +1535,47 @@ class ServiceIntegrationTests(unittest.TestCase):
             self.assertIn("Blocking: ACTIVE", state.gotify_messages[0]["message"])
             self.assertIn("Destination scope: ISP: DIGI / last 24h", state.gotify_messages[0]["message"])
 
+    def test_ntfy_notification_is_sent_for_block_change(self) -> None:
+        state = FakeState(
+            status_payload={"isBlocked": True},
+            ip_lines=["192.0.2.10", "198.51.100.0/24"],
+            route={
+                "_id": "route-1",
+                "name": "LaLiga",
+                "enabled": False,
+                "network_id": "vpn-network-1",
+                "target_devices": [{"client_mac": "aa:bb:cc:dd:ee:01", "type": "CLIENT"}],
+                "ip_addresses": [{"ip_or_subnet": "203.0.113.0/24", "ip_version": "IPv4"}],
+            },
+        )
+        with (
+            tempfile.TemporaryDirectory() as tmpdir,
+            TestServer(state, https=True) as unifi,
+            TestServer(state, https=False) as feed,
+        ):
+            state_path = Path(tmpdir) / "state.json"
+            state_path.write_text(json.dumps({"last_is_blocked": False}), encoding="utf-8")
+            config = self.make_config(
+                state_dir=tmpdir,
+                port=int(unifi.base_url.rsplit(":", 1)[1]),
+                status_url=f"{feed.base_url}/feed/status.json",
+                ip_list_url=f"{feed.base_url}/feed/ip_list.txt",
+                ntfy_url=f"{feed.base_url}/ntfy",
+                ntfy_topic="stopliga-test",
+                ntfy_token="tk_secret",
+                ntfy_priority=4,
+            )
+            StopLigaService(config).run_once()
+
+            self.assertEqual(len(state.ntfy_messages), 1)
+            self.assertEqual(state.ntfy_messages[0]["path"], "/ntfy/stopliga-test")
+            self.assertEqual(state.ntfy_messages[0]["title"], "StopLiga")
+            self.assertEqual(state.ntfy_messages[0]["priority"], "4")
+            self.assertEqual(state.ntfy_messages[0]["authorization"], "Bearer tk_secret")
+            self.assertIn("Route: LaLiga", state.ntfy_messages[0]["body"])
+            self.assertIn("Block status: INACTIVE -> ACTIVE", state.ntfy_messages[0]["body"])
+            self.assertIn("Blocking: ACTIVE", state.ntfy_messages[0]["body"])
+
     def test_telegram_notification_is_sent_for_block_change(self) -> None:
         state = FakeState(
             status_payload={"isBlocked": False},
@@ -1778,6 +1841,38 @@ class ServiceIntegrationTests(unittest.TestCase):
             StopLigaService(config).run_once()
 
             self.assertEqual(state.gotify_messages, [])
+
+    def test_destination_only_change_does_not_send_ntfy_message(self) -> None:
+        state = FakeState(
+            status_payload={"isBlocked": True},
+            ip_lines=["192.0.2.10", "198.51.100.0/24"],
+            route={
+                "_id": "route-1",
+                "name": "LaLiga",
+                "enabled": True,
+                "network_id": "vpn-network-1",
+                "target_devices": [{"client_mac": "aa:bb:cc:dd:ee:01", "type": "CLIENT"}],
+                "ip_addresses": [{"ip_or_subnet": "192.0.2.10", "ip_version": "IPv4"}],
+            },
+        )
+        with (
+            tempfile.TemporaryDirectory() as tmpdir,
+            TestServer(state, https=True) as unifi,
+            TestServer(state, https=False) as feed,
+        ):
+            state_path = Path(tmpdir) / "state.json"
+            state_path.write_text(json.dumps({"last_is_blocked": True}), encoding="utf-8")
+            config = self.make_config(
+                state_dir=tmpdir,
+                port=int(unifi.base_url.rsplit(":", 1)[1]),
+                status_url=f"{feed.base_url}/feed/status.json",
+                ip_list_url=f"{feed.base_url}/feed/ip_list.txt",
+                ntfy_url=f"{feed.base_url}/ntfy",
+                ntfy_topic="stopliga-test",
+            )
+            StopLigaService(config).run_once()
+
+            self.assertEqual(state.ntfy_messages, [])
 
     def test_notification_error_redacts_telegram_token(self) -> None:
         safe = _safe_notification_url("https://api.telegram.org/bot123456:secret-token/sendMessage")


### PR DESCRIPTION
## Summary

- Adds Ntfy as a third notification provider alongside Gotify and Telegram.
- Supports `STOPLIGA_NTFY_URL`, `STOPLIGA_NTFY_TOPIC`, optional bearer token, priority, TLS CA, and plain-HTTP override.
- Documents the `.env` and TOML configuration examples.

Fixes #17.

## Validation

- `.venv/bin/python -m ruff check src tests`
- `.venv/bin/python -m ruff format --check src tests`
- `.venv/bin/python -m mypy src`
- `.venv/bin/python -m compileall run_stopliga.py src tests`
- `.venv/bin/python -m pytest -q`
- `docker build -t stopliga:issue-17-ntfy-test --build-arg VERSION=0.1.25-issue17 .`
- `docker run --rm stopliga:issue-17-ntfy-test --help`

## Test Image

Local image built successfully as `stopliga:issue-17-ntfy-test`.

Pushing `ghcr.io/jcastro/stopliga:issue-17-ntfy-test` is blocked until the GitHub CLI token has `write:packages`.
